### PR TITLE
TECH - Add custom title strategy for page titles

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,6 +17,15 @@
       </li>
       <li>
         <a
+          routerLink="/flowers"
+          routerLinkActive="text-blue-500 underline"
+          ariaCurrentWhenActive="page"
+        >
+          Flowers
+        </a>
+      </li>
+      <li>
+        <a
           routerLink="/about"
           routerLinkActive="text-blue-500 underline"
           ariaCurrentWhenActive="page"

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,7 +2,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, TitleStrategy } from '@angular/router';
 
 import { routes } from './app.routes';
-import { PageTitleStrategy } from './services/page-title-strategy.service';
+import { PageTitleStrategy } from './core/page-title-strategy';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,13 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, TitleStrategy } from '@angular/router';
 
 import { routes } from './app.routes';
+import { PageTitleStrategy } from './services/page-title-strategy.service';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    { provide: TitleStrategy, useClass: PageTitleStrategy },
+  ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,19 +1,18 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './pages/home.component';
 import { AboutComponent } from './pages/about.component';
-import { setPageName } from './utils/set-page-name';
 
 export const routes: Routes = [
   {
     path: '',
     component: HomeComponent,
-    title: setPageName('Home'),
+    title: 'Home',
     pathMatch: 'full',
   },
   {
     path: 'about',
     component: AboutComponent,
-    title: setPageName('About'),
+    title: 'About',
   },
   {
     path: '**',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -15,6 +15,11 @@ export const routes: Routes = [
     title: 'About',
   },
   {
+    path: 'flowers',
+    loadComponent: () => import('./pages/flowers.component'),
+    title: 'Flowers'
+  },
+  {
     path: '**',
     redirectTo: '',
   },

--- a/src/app/core/page-title-strategy.ts
+++ b/src/app/core/page-title-strategy.ts
@@ -9,7 +9,7 @@ export class PageTitleStrategy extends TitleStrategy {
 
   override updateTitle(routerState: RouterStateSnapshot) {
     const title = this.buildTitle(routerState);
-    if (title !== undefined) {
+    if (title) {
       this.title.setTitle(setPageName(title));
     }
   }

--- a/src/app/pages/flowers.component.ts
+++ b/src/app/pages/flowers.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-flowers',
+  standalone: true,
+  imports: [],
+  template: `<p>This is flowers page!</p>`,
+  styles: ``
+})
+export default class FlowersComponent {
+
+}

--- a/src/app/services/page-title-strategy.service.ts
+++ b/src/app/services/page-title-strategy.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { setPageName } from '../utils/set-page-name';
+
+@Injectable({ providedIn: 'root' })
+export class PageTitleStrategy extends TitleStrategy {
+  constructor(private readonly title: Title) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot) {
+    const title = this.buildTitle(routerState);
+    if (title !== undefined) {
+      this.title.setTitle(setPageName(title));
+    }
+  }
+}

--- a/src/app/services/page-title-strategy.service.ts
+++ b/src/app/services/page-title-strategy.service.ts
@@ -1,13 +1,11 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
 import { setPageName } from '../utils/set-page-name';
 
 @Injectable({ providedIn: 'root' })
 export class PageTitleStrategy extends TitleStrategy {
-  constructor(private readonly title: Title) {
-    super();
-  }
+  title = inject(Title);
 
   override updateTitle(routerState: RouterStateSnapshot) {
     const title = this.buildTitle(routerState);


### PR DESCRIPTION
## 🦄 Description

Cette PR permets de spécifier le nom des pages de l'application en utilisant un custom `TitleStrategy`.

On ajoute également une nouvelle page `flowers` pour tester la simplification de déclaration des composants `lazy`.